### PR TITLE
Feature/reduce remote entry noise

### DIFF
--- a/apps/MFE/Header/public/app.html
+++ b/apps/MFE/Header/public/app.html
@@ -14,6 +14,7 @@
         appProps: __APP_PROPS__,
       }
     </script>
+    __REMOTE_ENTRIES_JS__
     <title>Batman: Header MFE</title>
   </head>
 

--- a/config/webpack/plugins/remotePlugins.js
+++ b/config/webpack/plugins/remotePlugins.js
@@ -1,76 +1,26 @@
-const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
-const HtmlWebpackPlugin = require('html-webpack-plugin')
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin')
-const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin')
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin')
 const webpack = require('webpack')
 
 const getClientEnvironment = require('../../env')
 const paths = require('../../paths')
-const {getRemotes, getHtmlPlugin} = require('../util')
-// eslint-disable-next-line import/no-dynamic-require
-const {version} = require(paths.appPackageJson)
+const {getRemotes} = require('../util')
 // eslint-disable-next-line import/no-dynamic-require
 const {getFederationConfig} = require(`${paths.federationConfigPath}/server`)
 
-const remotePlugins = webpackEnv => {
-  const isEnvDevelopment = webpackEnv === 'development'
-  const isEnvProduction = webpackEnv === 'production'
-
-  // We will provide `paths.publicUrlOrPath` to our app
-  // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
-  // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
+const remotePlugins = () => {
   // Get environment variables to inject into our app.
   const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1))
 
   const remotes = getRemotes()
   const federationConfig = getFederationConfig(remotes)
 
-  // Some apps do not need the benefits of saving a web request, so not inlining the chunk
-  // makes for a smoother build process.
-  const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false'
-
   return [
-    getHtmlPlugin(isEnvProduction),
-    // Inlines the webpack runtime script. This script is too small to warrant
-    // a network request.
-    // https://github.com/facebook/create-react-app/issues/5358
-    isEnvProduction && shouldInlineRuntimeChunk && new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime-.+[.]js/]),
-    // Makes some environment variables available in index.html.
-    // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
-    // <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
-    // It will be an empty string unless you specify "homepage"
-    // in `package.json`, in which case it will be the pathname of that URL.
-    new InterpolateHtmlPlugin(HtmlWebpackPlugin, env.raw),
     // This gives some necessary context to module not found errors, such as
     // the requesting resource.
     new ModuleNotFoundPlugin(paths.appPath),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
-    // It is absolutely essential that NODE_ENV is set to production
-    // during a production build.
-    // Otherwise React will be compiled in the very slow development mode.
     new webpack.DefinePlugin(env.stringified),
-    // Watcher doesn't work well if you mistype casing in a path so we use
-    // a plugin that prints an error when you attempt to do this.
-    // See https://github.com/facebook/create-react-app/issues/240
-    isEnvDevelopment && new CaseSensitivePathsPlugin(),
-    new MiniCssExtractPlugin({
-      // Options similar to the same options in webpackOptions.output
-      // both options are optional
-      filename: `static/css/[name].${version}.css`,
-      chunkFilename: `static/css/[name].${version}.chunk.css`,
-    }),
-    // Moment.js is an extremely popular library that bundles large locale files
-    // by default due to how webpack interprets its code. This is a practical
-    // solution that requires the user to opt into importing specific locales.
-    // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-    // You can remove this if you don't use Moment.js:
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^\.\/locale$/,
-      contextRegExp: /moment$/,
-    }),
     new webpack.container.ModuleFederationPlugin(federationConfig),
   ].filter(Boolean)
 }

--- a/config/webpack/remote.js
+++ b/config/webpack/remote.js
@@ -11,7 +11,7 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false'
 
 module.exports = webpackEnv => {
   const baseConfig = baseClientConfig(webpackEnv)
-  const isProduction = webpackEnv === 'production'
+  // const isProduction = webpackEnv === 'production'
   const remoteConfig = {
     target: 'node',
     externals: [nodeExternals()],
@@ -22,7 +22,7 @@ module.exports = webpackEnv => {
       path: `${paths.appSrc}/remote-entry`,
     },
     optimization: {
-      minimize: isProduction,
+      minimize: false,
       splitChunks: false,
     },
     plugins: [...remotePlugins(webpackEnv)].filter(Boolean),

--- a/config/webpack/remote.js
+++ b/config/webpack/remote.js
@@ -11,7 +11,7 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false'
 
 module.exports = webpackEnv => {
   const baseConfig = baseClientConfig(webpackEnv)
-  // const isProduction = webpackEnv === 'production'
+  const isProduction = webpackEnv === 'production'
   const remoteConfig = {
     target: 'node',
     externals: [nodeExternals()],
@@ -22,7 +22,7 @@ module.exports = webpackEnv => {
       path: `${paths.appSrc}/remote-entry`,
     },
     optimization: {
-      minimize: false,
+      minimize: isProduction,
       splitChunks: false,
     },
     plugins: [...remotePlugins(webpackEnv)].filter(Boolean),

--- a/libs/ui-components/Text/src/components/Text/Text.tsx
+++ b/libs/ui-components/Text/src/components/Text/Text.tsx
@@ -1,3 +1,3 @@
 export const Text = () => {
-  return <div>Shared text</div>
+  return <>Shared text</>
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "text-positioner:test": "npm run test -w @batman/text-positioner --if-present",
     "text-positioner:ratchet": "npm run jest-ratchet -w @batman/text-positioner --if-present",
     "text-positioner:serve": "npm run serve -w @batman/text-positioner --if-present",
-    "@batman-ui-components/text:build": "npm run build -w batman-ui-components/text --if-present",
+    "@batman-ui-components/text:build": "npm run build -w @batman-ui-components/text --if-present",
     "@batman-ui-components/text:lint": "npm run lint -w @batman-ui-components/text --if-present",
     "@batman-ui-components/text:test": "npm run test -w @batman-ui-components/text --if-present",
     "@batman-ui-components/text:ratchet": "npm run jest-ratchet -w @batman-ui-components/text --if-present",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "text-positioner:test": "npm run test -w @batman/text-positioner --if-present",
     "text-positioner:ratchet": "npm run jest-ratchet -w @batman/text-positioner --if-present",
     "text-positioner:serve": "npm run serve -w @batman/text-positioner --if-present",
+    "text-positioner:watch": "npm run watch -w @batman/text-positioner --if-present",
     "@batman-ui-components/text:build": "npm run build -w @batman-ui-components/text --if-present",
     "@batman-ui-components/text:lint": "npm run lint -w @batman-ui-components/text --if-present",
     "@batman-ui-components/text:test": "npm run test -w @batman-ui-components/text --if-present",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -54,7 +54,6 @@ const build = async previousFileSizes => {
     // remove the remote-entry generated static files that we don't need anymore
     const remoteEntryFolder = `${paths.appSrc}/remote-entry`
     fs.rmSync(`${remoteEntryFolder}/static`, {recursive: true, force: true})
-    fs.rmSync(`${remoteEntryFolder}/app.html`, {force: true})
 
     // remove remote-entry if the folder is empty
     const files = fs.readdirSync(remoteEntryFolder)

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -54,7 +54,6 @@ const build = async previousFileSizes => {
     // remove the remote-entry generated static files that we don't need anymore
     const remoteEntryFolder = `${paths.appSrc}/remote-entry`
     fs.rmSync(`${remoteEntryFolder}/static`, {recursive: true, force: true})
-    fs.rmSync(`${remoteEntryFolder}/app.html`, {force: true})
 
     // remove remote-entry if the folder is empty
     const files = fs.readdirSync(remoteEntryFolder)


### PR DESCRIPTION
- Remove HTML plugins from remote-entry webpack build.

For some reason stopping the chunks from being output using [filter-chunk-plugin](https://github.com/yeojz/filter-chunk-webpack-plugin) breaks module federation, even though we delete those files afterwards.